### PR TITLE
(MAINT) Revert container image

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	moduleOwner  = "puppetlabs"
-	imageName    = "ghcr.io/puppetlabs/cat-team-github-metrics:v0.1.1"
+	imageName    = "ghcr.io/chelnak/cat-team-github-metrics:v0.1.1"
 	scheduleCron = "0 0 * * *"
 	scheduleType = "schedule"
 )


### PR DESCRIPTION
This commit reverts the container image back to the publicly available image from chelnak/cat-team-github-metrics.