### PR TITLE
(maint) - Replace deprecated --rm-dist flag in goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: --snapshot --rm-dist
+        args: --snapshot --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WORKINGDIR: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: nightly - 
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  GO_VERSION: 1.18
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        distribution: goreleaser
+        version: latest
+        args: --snapshot --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WORKINGDIR: ${{ env.GITHUB_WORKSPACE }}
+
+    - name: Trivy Scan
+      uses: docker://docker.io/aquasec/trivy:0.45.0
+      with:
+        args: 'i --vuln-type os --ignore-unfixed -s CRITICAL ghcr.io/puppetlabs/cat-team-github-metrics:latest'


### PR DESCRIPTION
--rm-dist has been deprecated in favour of --clean see
https://goreleaser.com/deprecations/#-rm-dist