### PR TITLE
(maint) Increase oauth2-v0.7.0 to oauth2-v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.12.0
 	golang.org/x/net v0.27.0
-	golang.org/x/oauth2 v0.7.0
+	golang.org/x/oauth2 v0.27.0
 )
 
 require (


### PR DESCRIPTION
The current version of oauth2 is being detected by mend. Upgrading to oauth2-v0.27.0